### PR TITLE
Exclude applovin library from adapters.

### DIFF
--- a/Audienzz/build.gradle.kts
+++ b/Audienzz/build.gradle.kts
@@ -48,6 +48,10 @@ android {
     lint.checkDependencies = true
 }
 
+configurations.configureEach {
+    exclude(group = "com.applovin")
+}
+
 afterEvaluate {
     publishing {
         repositories.maven {


### PR DESCRIPTION
Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes. For more information about compatibility with 16 KB devices, visit developer.android.com/16kb-page-size. Discussed with Hannes we can exclude lovin since it is not used. Having 16KB violating library block application from the release.