### PR TITLE
Fix can't call setPrebidSubjectToGdpr() before PrebidMobile.initializeSdk().

### DIFF
--- a/Example/TestApp/src/main/java/org/audienzz/mobile/testapp/App.kt
+++ b/Example/TestApp/src/main/java/org/audienzz/mobile/testapp/App.kt
@@ -7,11 +7,6 @@ class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        preInitSdk()
-    }
-
-    private fun preInitSdk() {
-        AudienzzTargetingParams.isSubjectToGDPR = true
     }
 
     companion object {

--- a/Example/TestApp/src/main/java/org/audienzz/mobile/testapp/view/AdsPageFragment.kt
+++ b/Example/TestApp/src/main/java/org/audienzz/mobile/testapp/view/AdsPageFragment.kt
@@ -10,6 +10,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import org.audienzz.mobile.AudienzzPrebidMobile
 import org.audienzz.mobile.AudienzzPrebidMobile.setSchainObject
+import org.audienzz.mobile.AudienzzTargetingParams
 import org.audienzz.mobile.api.data.AudienzzInitializationStatus
 import org.audienzz.mobile.testapp.AdPreferences
 import org.audienzz.mobile.testapp.App
@@ -67,6 +68,7 @@ class AdsPageFragment : Fragment() {
 
     private fun initSdk() {
         if (AudienzzPrebidMobile.isSdkInitialized) {
+            AudienzzTargetingParams.isSubjectToGDPR = true
             binding.progressBar.isVisible = false
             adapter.submitList(createMockData())
             return
@@ -101,6 +103,7 @@ class AdsPageFragment : Fragment() {
 
     private fun handleInitializationStatus(status: AudienzzInitializationStatus) {
         if (status == AudienzzInitializationStatus.SUCCEEDED) {
+            AudienzzTargetingParams.isSubjectToGDPR = true
             adapter.submitList(createMockData())
             binding.progressBar.isVisible = false
             setSchainObject(


### PR DESCRIPTION
Updating `prebidSubjectToGdpr` before calling `PrebidMobile.initializeSdk()` produces error. This can mess up users so I have moved it into library initialization callback.