### PR TITLE
Mute GMA ads by default via setAppMuted (backend-driven)

### DIFF
--- a/Audienzz/build.gradle.kts
+++ b/Audienzz/build.gradle.kts
@@ -17,7 +17,7 @@ ksp {
     arg(RoomSchemaArgProvider(File(projectDir, "schemas")))
 }
 
-val audienzzSdkVersion = "0.1.4"
+val audienzzSdkVersion = "0.1.5"
 
 android {
     compileSdk = libs.versions.sdk.compile.get().toInt()

--- a/Audienzz/src/main/java/org/audienzz/mobile/AudienzzPrebidMobile.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/AudienzzPrebidMobile.kt
@@ -468,7 +468,8 @@ object AudienzzPrebidMobile {
         val volume = (gamConfig?.appVolume ?: 0f).coerceIn(0f, 1f)
         MobileAds.initialize(context) {
             MobileAds.setAppVolume(volume)
-            android.util.Log.d(TAG, "GMA app volume set to $volume")
+            MobileAds.setAppMuted(volume == 0f)
+            android.util.Log.d(TAG, "GMA app volume set to $volume, muted=${volume == 0f}")
         }
     }
 
@@ -515,7 +516,8 @@ object AudienzzPrebidMobile {
             android.util.Log.w(TAG, "setAppVolume: $volume is out of [0.0, 1.0], clamped to $clamped")
         }
         MobileAds.setAppVolume(clamped)
-        android.util.Log.d(TAG, "GMA app volume updated to $clamped")
+        MobileAds.setAppMuted(clamped == 0f)
+        android.util.Log.d(TAG, "GMA app volume updated to $clamped, muted=${clamped == 0f}")
     }
 
     /**


### PR DESCRIPTION
Set the GMA mute flag alongside app volume so ads are muted when the backend-driven volume resolves to 0, and audible when it is non-zero. Previously only applicationVolume/appVolume was set (never the mute flag), so GMA full-screen video ads could still play audio.