### PR TITLE
Fix audit findings: refresh loops, lifecycle, callbacks, config, targeting

### DIFF
--- a/Audienzz/src/main/java/org/audienzz/mobile/AudienzzPrebidMobile.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/AudienzzPrebidMobile.kt
@@ -339,6 +339,8 @@ object AudienzzPrebidMobile {
     ) {
         this.companyId = companyId
         val listener = SdkInitializationListener { status ->
+            // M5: flush any consent/COPPA values the publisher set before init reached Prebid.
+            AudienzzTargetingParams.onPrebidInitialized()
             sdkInitializationListener?.onInitializationComplete(
                 AudienzzInitializationStatus.fromPrebidInitializationStatus(status),
             )
@@ -400,6 +402,8 @@ object AudienzzPrebidMobile {
                 }
 
                 val listener = SdkInitializationListener { status ->
+                    // M5: flush any consent/COPPA values the publisher set before init reached Prebid.
+                    AudienzzTargetingParams.onPrebidInitialized()
                     sdkInitializationListener?.onInitializationComplete(
                         AudienzzInitializationStatus.fromPrebidInitializationStatus(status),
                     )
@@ -553,8 +557,11 @@ object AudienzzPrebidMobile {
      */
     @JvmStatic
     fun setSchainObject(schain: String) {
+        // H6: store the schain as its own source and rebuild the canonical global ORTB. Routing it
+        // through setGlobalOrtbConfig would have stored the schain AS the publisher's ORTB and let
+        // a later targeting change wipe it (and vice-versa).
         schainObject = JSONObject(schain)
-        AudienzzTargetingParams.setGlobalOrtbConfig(JSONObject(schain))
+        AudienzzTargetingParams.rebuildGlobalOrtb()
     }
 
     private fun getPrebidMobilePluginRenderer(

--- a/Audienzz/src/main/java/org/audienzz/mobile/AudienzzRemoteBannerView.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/AudienzzRemoteBannerView.kt
@@ -56,9 +56,17 @@ class AudienzzRemoteBannerView @JvmOverloads constructor(
     }
 
     fun destroy() {
-        adViewHandler?.disableSmartRefresh()
+        // H1: route through the handler so Prebid's ad unit is actually destroyed (its BidLoader
+        // torn down), not merely paused. Fall back to stopping/destroying the unit directly if the
+        // handler was never created (config load failed before createAdFromConfig).
+        val handler = adViewHandler
+        if (handler != null) {
+            handler.destroy()
+        } else {
+            adUnit?.stopAutoRefresh()
+            adUnit?.destroy()
+        }
         adViewHandler = null
-        adUnit?.stopAutoRefresh()
         adUnit = null
         adView?.destroy()
         adView = null
@@ -67,11 +75,15 @@ class AudienzzRemoteBannerView @JvmOverloads constructor(
     }
 
     fun onResume() {
-        adUnit?.resumeAutoRefresh()
+        // H4/M10: resume through the handler's stale-aware smart refresh, which restores the
+        // correct remaining interval instead of resetting Prebid's timer to a full interval.
+        adViewHandler?.resumeSmartRefresh() ?: adUnit?.resumeAutoRefresh()
     }
 
     fun onPause() {
-        adUnit?.stopAutoRefresh()
+        // H4: cancel any pending postDelayed refresh runnable too — stopping only Prebid's timer
+        // left the scheduled runnable to fire while backgrounded, issuing ad requests off-screen.
+        adViewHandler?.pauseSmartRefresh() ?: adUnit?.stopAutoRefresh()
     }
 
     fun setAdListener(listener: AdListener) {
@@ -104,6 +116,14 @@ class AudienzzRemoteBannerView @JvmOverloads constructor(
 
     @Suppress("SpreadOperator")
     private fun createAdFromConfig(config: RemoteAdUnitConfig) {
+        // M11: a second loadAd()/createAdFromConfig would otherwise orphan the previous ad unit and
+        // ad view with their refresh loop still armed (a zombie loop loading a detached view, feeding
+        // C1). Tear the predecessor down before building the replacement.
+        adViewHandler?.destroy()
+        adViewHandler = null
+        adUnit = null
+        adView?.destroy()
+        adView = null
         removeAllViews()
 
         val gamConfig = config.gamConfig

--- a/Audienzz/src/main/java/org/audienzz/mobile/AudienzzRemoteConfigInterstitial.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/AudienzzRemoteConfigInterstitial.kt
@@ -33,6 +33,13 @@ class AudienzzRemoteConfigInterstitial(
         fun onClosed()
         fun onClicked()
         fun onFailedToShow(adError: AdError)
+
+        /**
+         * M6: SDK-internal failure that has no GAM [LoadAdError]/[AdError] to report — a missing
+         * remote config, an uninitialized SDK, or no Activity available to show the interstitial.
+         * Default no-op so existing implementers keep compiling.
+         */
+        fun onError(reason: String) {}
     }
     private var interstitialAdHandler: AudienzzInterstitialAdHandler? = null
     private var loadedInterstitialAd: AdManagerInterstitialAd? = null
@@ -47,6 +54,7 @@ class AudienzzRemoteConfigInterstitial(
             val manager = MainComponent.Companion.remoteConfigManager
             if (manager == null) {
                 Log.e(TAG, "RemoteConfigManager is not initialized")
+                events?.onError("RemoteConfigManager is not initialized — call initializeRemoteSdk first")
                 return@launch
             }
 
@@ -56,6 +64,7 @@ class AudienzzRemoteConfigInterstitial(
 
             if (config == null) {
                 Log.e(TAG, "Config not found for ID: $configId")
+                events?.onError("Remote config not found for ID: $configId")
                 return@launch
             }
 
@@ -88,8 +97,14 @@ class AudienzzRemoteConfigInterstitial(
                     Log.d(TAG, "Ad loaded, auto-showing. ConfigId $configId")
                     loadedInterstitialAd = interstitialAd
                     events?.onLoaded()
-                    context.getActivity()?.let {
-                        loadedInterstitialAd?.show(it)
+                    val activity = context.getActivity()
+                    if (activity != null) {
+                        loadedInterstitialAd?.show(activity)
+                    } else {
+                        // M6: a non-Activity context silently never shows — a paid auction with
+                        // zero impressions. Surface it instead of swallowing.
+                        Log.e(TAG, "No Activity context available to show interstitial for ConfigId $configId")
+                        events?.onError("No Activity context available to show interstitial for ConfigId $configId")
                     }
                     super.onAdLoaded(interstitialAd)
                 }
@@ -133,6 +148,9 @@ class AudienzzRemoteConfigInterstitial(
     }
 
     fun destroy() {
+        // M6: drop the loaded ad and handler so a destroyed instance can't retain/show a stale ad.
+        loadedInterstitialAd = null
+        interstitialAdHandler = null
         scope.cancel()
     }
 

--- a/Audienzz/src/main/java/org/audienzz/mobile/AudienzzStickyAdWrapperView.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/AudienzzStickyAdWrapperView.kt
@@ -410,6 +410,10 @@ public class AudienzzStickyAdWrapperView @JvmOverloads constructor(
         private val nestedWrappers:
             WeakHashMap<NestedScrollView, MutableSet<AudienzzStickyAdWrapperView>> = WeakHashMap()
 
+        /** The one shared VTO scroll listener per scroll view, so it can be removed on teardown. */
+        private val nestedScrollListeners:
+            WeakHashMap<NestedScrollView, ViewTreeObserver.OnScrollChangedListener> = WeakHashMap()
+
         private fun registerNestedWrapper(
             scrollView: NestedScrollView,
             wrapper: AudienzzStickyAdWrapperView,
@@ -418,18 +422,26 @@ public class AudienzzStickyAdWrapperView @JvmOverloads constructor(
             val wrappers = nestedWrappers.getOrPut(scrollView) { mutableSetOf() }
             wrappers.add(wrapper)
 
-            // Only set the scroll listener once per scroll view — it reads the wrapper
-            // set dynamically from nestedWrappers, so all wrappers registered later are
-            // automatically included without replacing the listener.
+            // Only add the scroll listener once per scroll view — it reads the wrapper set
+            // dynamically from nestedWrappers, so wrappers registered later are automatically
+            // included without replacing the listener.
             if (isFirstWrapper) {
-                scrollView.setOnScrollChangeListener { _: NestedScrollView, _: Int, _: Int, _: Int, _: Int ->
-                    val current = nestedWrappers[scrollView] ?: return@setOnScrollChangeListener
-                    if (current.isEmpty()) return@setOnScrollChangeListener
+                // M12: use the ADDITIVE ViewTreeObserver scroll listener instead of
+                // NestedScrollView.setOnScrollChangeListener (a single-slot setter). The setter
+                // overwrote any scroll listener the publisher had set on their own NestedScrollView
+                // and, on teardown, nulled it out — clobbering the publisher's listener for the
+                // scroll view's lifetime. A VTO listener coexists with the publisher's and is
+                // removed cleanly below.
+                val listener = ViewTreeObserver.OnScrollChangedListener {
+                    val current = nestedWrappers[scrollView] ?: return@OnScrollChangedListener
+                    if (current.isEmpty()) return@OnScrollChangedListener
                     current.forEach {
                         it.updatePosition()
                         it.startSettleTicker()
                     }
                 }
+                nestedScrollListeners[scrollView] = listener
+                scrollView.viewTreeObserver.addOnScrollChangedListener(listener)
             }
         }
 
@@ -440,7 +452,11 @@ public class AudienzzStickyAdWrapperView @JvmOverloads constructor(
             val wrappers = nestedWrappers[scrollView] ?: return
             wrappers.remove(wrapper)
             if (wrappers.isEmpty()) {
-                scrollView.setOnScrollChangeListener(null as NestedScrollView.OnScrollChangeListener?)
+                nestedScrollListeners.remove(scrollView)?.let { listener ->
+                    if (scrollView.viewTreeObserver.isAlive) {
+                        scrollView.viewTreeObserver.removeOnScrollChangedListener(listener)
+                    }
+                }
                 nestedWrappers.remove(scrollView)
             }
         }

--- a/Audienzz/src/main/java/org/audienzz/mobile/AudienzzTargetingParams.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/AudienzzTargetingParams.kt
@@ -80,17 +80,53 @@ object AudienzzTargetingParams {
             TargetingParams.setOmidPartnerVersion(value)
         }
 
+    // M5: these consent/COPPA setters passthrough to Prebid statics that error-log and DROP the
+    // value if called before Prebid init — so consent set pre-init could be missing from bid
+    // requests. Buffer pre-init writes and replay them in the init listener (see
+    // [onPrebidInitialized]); getters prefer the buffered value until init completes.
+    @Volatile
+    private var prebidInitialized = false
+
+    private class PendingValue<T> {
+        var isSet = false
+            private set
+        var value: T? = null
+            private set
+
+        fun set(newValue: T?) {
+            value = newValue
+            isSet = true
+        }
+    }
+
+    private val pendingCoppa = PendingValue<Boolean>()
+    private val pendingGdpr = PendingValue<Boolean>()
+    private val pendingGdprConsent = PendingValue<String>()
+    private val pendingPurposeConsents = PendingValue<String>()
+
+    /**
+     * M5: called by [AudienzzPrebidMobile] once Prebid finishes initializing. Flushes any
+     * consent/COPPA values the publisher set before init so they reach Prebid's statics.
+     */
+    @JvmStatic
+    internal fun onPrebidInitialized() {
+        prebidInitialized = true
+        if (pendingCoppa.isSet) TargetingParams.setSubjectToCOPPA(pendingCoppa.value)
+        if (pendingGdpr.isSet) TargetingParams.setSubjectToGDPR(pendingGdpr.value)
+        if (pendingGdprConsent.isSet) TargetingParams.setGDPRConsentString(pendingGdprConsent.value)
+        if (pendingPurposeConsents.isSet) TargetingParams.setPurposeConsents(pendingPurposeConsents.value)
+    }
+
     /**
      * Sets subject to COPPA. Null to set undefined. <br><br>
      * <p>
-     * Must be called only after
-     * {@link PrebidMobile#initializeSdk(Context, SdkInitializationListener)}.
+     * Values set before SDK init are buffered and applied once init completes.
      */
     @JvmStatic
     var isSubjectToCOPPA: Boolean?
-        get() = TargetingParams.isSubjectToCOPPA()
+        get() = if (!prebidInitialized && pendingCoppa.isSet) pendingCoppa.value else TargetingParams.isSubjectToCOPPA()
         set(value) {
-            TargetingParams.setSubjectToCOPPA(value)
+            if (prebidInitialized) TargetingParams.setSubjectToCOPPA(value) else pendingCoppa.set(value)
         }
 
     /**
@@ -104,9 +140,9 @@ object AudienzzTargetingParams {
      */
     @JvmStatic
     var isSubjectToGDPR: Boolean?
-        get() = TargetingParams.isSubjectToGDPR()
+        get() = if (!prebidInitialized && pendingGdpr.isSet) pendingGdpr.value else TargetingParams.isSubjectToGDPR()
         set(value) {
-            TargetingParams.setSubjectToGDPR(value)
+            if (prebidInitialized) TargetingParams.setSubjectToGDPR(value) else pendingGdpr.set(value)
         }
 
     /**
@@ -120,9 +156,9 @@ object AudienzzTargetingParams {
      */
     @JvmStatic
     var gdprConsentString: String?
-        get() = TargetingParams.getGDPRConsentString()
+        get() = if (!prebidInitialized && pendingGdprConsent.isSet) pendingGdprConsent.value else TargetingParams.getGDPRConsentString()
         set(value) {
-            TargetingParams.setGDPRConsentString(value)
+            if (prebidInitialized) TargetingParams.setGDPRConsentString(value) else pendingGdprConsent.set(value)
         }
 
     /**
@@ -136,9 +172,9 @@ object AudienzzTargetingParams {
      */
     @JvmStatic
     var purposeConsents: String?
-        get() = TargetingParams.getPurposeConsents()
+        get() = if (!prebidInitialized && pendingPurposeConsents.isSet) pendingPurposeConsents.value else TargetingParams.getPurposeConsents()
         set(value) {
-            TargetingParams.setPurposeConsents(value)
+            if (prebidInitialized) TargetingParams.setPurposeConsents(value) else pendingPurposeConsents.set(value)
         }
 
     /**
@@ -327,29 +363,39 @@ object AudienzzTargetingParams {
     @JvmStatic
     fun getGlobalOrtbConfig(): String? = TargetingParams.getGlobalOrtbConfig()
 
+    /** The publisher's own global ORTB, kept separately so SDK-managed sources never wipe it. */
+    private var publisherOrtbConfig: JSONObject? = null
+
     /**
      * Sets global OpenRTB JSON string for merging with the original request.
      * Expected format: "{"new_field": "value"}".
      * Params:
      * ortbConfig – JSONObject containing OpenRTB string.
+     *
+     * H6: the publisher's ORTB is now stored and folded into the single canonical global ORTB
+     * (see [rebuildGlobalOrtb]) rather than replacing it — so a later targeting or schain change
+     * no longer discards it, and this call no longer discards accumulated keywords/schain.
      */
     @JvmStatic
     fun setGlobalOrtbConfig(ortbConfig: JSONObject) {
-        val schainObject = AudienzzPrebidMobile.schainObject
+        publisherOrtbConfig = ortbConfig
+        rebuildGlobalOrtb()
+    }
 
-        var config: JSONObject = if (schainObject != null) {
-            AudienzzUtil.mergeJsonObjects(
-                schainObject,
-                ortbConfig,
-            )
-        } else {
-            ortbConfig
-        }
-
-        // Always embed Audienzz SDK metadata in app.ext.audienzz so every
-        // Prebid request carries the SDK identifier and version.
+    /**
+     * H6: rebuild the one canonical global ORTB from every source the SDK owns — the publisher's
+     * own ORTB, the schain, the accumulated custom-targeting keywords, and the SDK identity — and
+     * push it to Prebid in a single call. Every targeting/schain mutation funnels through here, so
+     * no source can wipe another (previously each mutation replaced Prebid's global ORTB with only
+     * its own slice). SDK-managed sources are merged last so their reserved namespaces win.
+     */
+    @JvmStatic
+    internal fun rebuildGlobalOrtb() {
+        var config = JSONObject()
+        publisherOrtbConfig?.let { config = AudienzzUtil.mergeJsonObjects(config, it) }
+        AudienzzPrebidMobile.schainObject?.let { config = AudienzzUtil.mergeJsonObjects(config, it) }
+        config = AudienzzUtil.mergeJsonObjects(config, CUSTOM_TARGETING_MANAGER.buildOrtbCustomTargeting())
         config = AudienzzUtil.mergeJsonObjects(config, SDK_META_ORTB)
-
         TargetingParams.setGlobalOrtbConfig(config.toString())
     }
 
@@ -389,21 +435,21 @@ object AudienzzTargetingParams {
         CUSTOM_TARGETING_MANAGER.setReservedTargeting(key, value)
         val ortbKey = if (key.startsWith("au_")) key.removePrefix("au_") else key
         bridgeOrtbFields[ortbKey] = value
-        setGlobalOrtbConfig(CUSTOM_TARGETING_MANAGER.buildOrtbCustomTargeting())
+        rebuildGlobalOrtb()
     }
 
     /** Add a key-value global targeting */
     @JvmStatic
     fun addGlobalTargeting(key: String, value: String) {
         CUSTOM_TARGETING_MANAGER.addCustomTargeting(key, value)
-        setGlobalOrtbConfig(CUSTOM_TARGETING_MANAGER.buildOrtbCustomTargeting())
+        rebuildGlobalOrtb()
     }
 
     /** Add a key values global targeting */
     @JvmStatic
     fun addGlobalTargeting(key: String, value: Set<String>) {
         CUSTOM_TARGETING_MANAGER.addCustomTargeting(key, value)
-        setGlobalOrtbConfig(CUSTOM_TARGETING_MANAGER.buildOrtbCustomTargeting())
+        rebuildGlobalOrtb()
     }
 
     /** Replace the value set for an existing key */
@@ -411,7 +457,7 @@ object AudienzzTargetingParams {
     fun updateGlobalTargeting(key: String, value: Set<String>) {
         CUSTOM_TARGETING_MANAGER.removeCustomTargeting(key)
         CUSTOM_TARGETING_MANAGER.addCustomTargeting(key, value)
-        setGlobalOrtbConfig(CUSTOM_TARGETING_MANAGER.buildOrtbCustomTargeting())
+        rebuildGlobalOrtb()
     }
 
     /** Remove targeting for a key — silently skips SDK-reserved keys. */
@@ -419,31 +465,16 @@ object AudienzzTargetingParams {
     fun removeGlobalTargeting(key: String) {
         // CustomTargetingManager.removeCustomTargeting already skips reserved keys
         CUSTOM_TARGETING_MANAGER.removeCustomTargeting(key)
-        setGlobalOrtbConfig(CUSTOM_TARGETING_MANAGER.buildOrtbCustomTargeting())
+        rebuildGlobalOrtb()
     }
 
     /** Clear global targeting */
     @JvmStatic
     fun clearGlobalTargeting() {
+        // H6: clear only the custom-targeting keywords, then rebuild the canonical ORTB. Publisher
+        // ORTB, schain and SDK identity are preserved because they are separate sources, not
+        // surgically carved out of the flattened Prebid config as before.
         CUSTOM_TARGETING_MANAGER.clearCustomTargeting()
-        val currentConfig = getGlobalOrtbConfig()
-        if (currentConfig != null) {
-            val configJson = JSONObject(currentConfig)
-
-            val appObj = configJson.optJSONObject("app") ?: return
-            val contentObj = appObj.optJSONObject("content") ?: return
-
-            contentObj.remove("keywords")
-
-            if (contentObj.length() == 0) {
-                appObj.remove("content")
-            }
-
-            if (appObj.length() == 0) {
-                configJson.remove("app")
-            }
-
-            TargetingParams.setGlobalOrtbConfig(configJson.toString())
-        }
+        rebuildGlobalOrtb()
     }
 }

--- a/Audienzz/src/main/java/org/audienzz/mobile/api/config/RemoteConfigApi.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/api/config/RemoteConfigApi.kt
@@ -1,5 +1,6 @@
 package org.audienzz.mobile.api.config
 
+import kotlinx.serialization.json.JsonArray
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -10,10 +11,12 @@ interface RemoteConfigApi {
         @Path("publisherId") publisherId: String,
     ): PublisherConfig
 
+    // H9: returns the raw JSON array (not List<RemoteAdUnitConfig>) so each element can be decoded
+    // independently — one malformed ad-unit config must not discard every other config.
     @GET("publishers/{publisherId}/ad-configs")
     suspend fun getAdUnitConfigs(
         @Path("publisherId") publisherId: String,
-    ): List<RemoteAdUnitConfig>
+    ): JsonArray
 
     @GET("publishers/{publisherId}/ad-configs/{adUnitConfigId}")
     suspend fun getAdUnitConfig(

--- a/Audienzz/src/main/java/org/audienzz/mobile/api/rendering/AudienzzInterstitialAdUnit.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/api/rendering/AudienzzInterstitialAdUnit.kt
@@ -103,6 +103,7 @@ class AudienzzInterstitialAdUnit(
         prebidInterstitialAdUnit.setInterstitialAdUnitListener(
             adUnitEventsListener?.let {
                 getInterstitialAdUnitListener(
+                    self = this,
                     adUnitId = adUnitId,
                     adUnitListener = it,
                 )
@@ -122,47 +123,43 @@ class AudienzzInterstitialAdUnit(
 
     companion object {
 
+        // C2: hand the publisher back [self] — the SAME wrapper they already hold — instead of a
+        // freshly constructed AudienzzInterstitialAdUnit. Constructing a new wrapper re-runs its
+        // init{}, which re-installs a no-op listener on the shared Prebid unit and clobbers the
+        // publisher's real listener, so every event after the first was silently dropped (and
+        // onAdClosed-chained reloads died). Reusing [self] keeps the publisher's listener intact.
         private fun getInterstitialAdUnitListener(
+            self: AudienzzInterstitialAdUnit,
             adUnitId: String,
             adUnitListener: AudienzzInterstitialAdUnitListener,
         ): InterstitialAdUnitListener {
             return object : InterstitialAdUnitListener {
                 override fun onAdLoaded(interstitialAdUnit: InterstitialAdUnit?) {
-                    interstitialAdUnit?.let {
-                        adUnitListener.onAdLoaded(AudienzzInterstitialAdUnit(it, adUnitId))
-                    }
+                    adUnitListener.onAdLoaded(self)
                 }
 
                 override fun onAdDisplayed(interstitialAdUnit: InterstitialAdUnit?) {
-                    interstitialAdUnit?.let {
-                        adUnitListener.onAdDisplayed(AudienzzInterstitialAdUnit(it, adUnitId))
-                    }
+                    adUnitListener.onAdDisplayed(self)
                 }
 
                 override fun onAdFailed(
                     interstitialAdUnit: InterstitialAdUnit?,
                     exception: AdException?,
                 ) {
-                    interstitialAdUnit?.let {
-                        adUnitListener.onAdFailed(
-                            AudienzzInterstitialAdUnit(it, adUnitId),
-                            exception?.let { e -> AudienzzAdException(e) },
-                        )
-                    }
+                    adUnitListener.onAdFailed(
+                        self,
+                        exception?.let { e -> AudienzzAdException(e) },
+                    )
                 }
 
                 override fun onAdClicked(interstitialAdUnit: InterstitialAdUnit?) {
                     eventLogger?.adClick(adUnitId = adUnitId)
-                    interstitialAdUnit?.let {
-                        adUnitListener.onAdClicked(AudienzzInterstitialAdUnit(it, adUnitId))
-                    }
+                    adUnitListener.onAdClicked(self)
                 }
 
                 override fun onAdClosed(interstitialAdUnit: InterstitialAdUnit?) {
                     eventLogger?.closeAd(adUnitId = adUnitId)
-                    interstitialAdUnit?.let {
-                        adUnitListener.onAdClosed(AudienzzInterstitialAdUnit(it, adUnitId))
-                    }
+                    adUnitListener.onAdClosed(self)
                 }
             }
         }

--- a/Audienzz/src/main/java/org/audienzz/mobile/di/MainComponent.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/di/MainComponent.kt
@@ -67,8 +67,11 @@ internal interface MainComponent {
             }
 
         fun init(context: Context) {
+            // M4: bind the application context, not the caller's context. Callers pass an Activity
+            // to initializeSdk; binding it here pinned that Activity for the process lifetime via
+            // the @Singleton graph.
             instance = DaggerMainComponent.builder()
-                .applicationContext(context)
+                .applicationContext(context.applicationContext)
                 .build()
         }
     }

--- a/Audienzz/src/main/java/org/audienzz/mobile/manager/RemoteConfigManager.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/manager/RemoteConfigManager.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.audienzz.mobile.api.config.PublisherConfig
@@ -23,18 +24,29 @@ class RemoteConfigManager @Inject constructor(
         },
     )
 
+    /** The in-flight initial network refresh, awaited once by readers on a cold-start cache miss. */
+    private var initialRefreshJob: Job? = null
+
     fun initialize(publisherId: String) {
         Log.d(TAG, "Initializing RemoteConfigManager for publisher: $publisherId")
-        scope.launch {
+        initialRefreshJob = scope.launch {
             repository.refreshConfig(publisherId)
         }
     }
 
     suspend fun getAdUnitConfig(configId: String): RemoteAdUnitConfig? {
         Log.d(TAG, "Getting ad unit config for ID: $configId")
-        val config = repository.getAdUnitConfig(configId)
+        var config = repository.getAdUnitConfig(configId)
         if (config == null) {
-            Log.w(TAG, "No config found for ID: $configId")
+            // H8: on a cold start the cache is empty only because the initial network refresh is
+            // still in flight. Await it once, then re-read — instead of returning null and leaving
+            // the caller (e.g. AudienzzRemoteBannerView) to log-and-give-up with no retry.
+            Log.d(TAG, "No cached config for ID: $configId — awaiting initial refresh, then retrying")
+            initialRefreshJob?.join()
+            config = repository.getAdUnitConfig(configId)
+        }
+        if (config == null) {
+            Log.w(TAG, "No config found for ID: $configId (after awaiting initial refresh)")
         } else {
             Log.d(TAG, "Config found for ID: $configId")
         }

--- a/Audienzz/src/main/java/org/audienzz/mobile/original/AudienzzAdViewHandler.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/original/AudienzzAdViewHandler.kt
@@ -23,6 +23,7 @@ import org.audienzz.mobile.util.addContinuousVisibilityListener
 import org.audienzz.mobile.util.adViewId
 import org.audienzz.mobile.util.addOnBecameVisibleOnScreenListener
 import org.audienzz.mobile.util.addPrefetchMarginListener
+import org.audienzz.mobile.util.isVisibleForSmartRefresh
 import org.audienzz.mobile.util.sizeString
 
 class AudienzzAdViewHandler(
@@ -34,13 +35,16 @@ class AudienzzAdViewHandler(
     }
 
     private var isFirstDemandFetch = true
+    private var eventListenerInstalled = false
 
     // Smart refresh state
     private var smartRefreshListener: ViewTreeObserver.OnPreDrawListener? = null
     private var lastRefreshTime: Long = 0
     private val refreshHandler = android.os.Handler(android.os.Looper.getMainLooper())
     private var pendingRefreshRunnable: Runnable? = null
-    private var storedRequest: AdManagerAdRequest? = null
+    // M1: keep the request BUILDER (not a frozen request) so each auction rebuilds a fresh request
+    // carrying the current PPID/consent/targeting rather than values baked in at first load().
+    private var gamRequestBuilder: AdManagerAdRequest.Builder? = null
     private var storedCallback: ((AdManagerAdRequest, AudienzzResultCode?) -> Unit)? = null
 
     init {
@@ -74,17 +78,7 @@ class AudienzzAdViewHandler(
         gamRequestBuilder: AdManagerAdRequest.Builder = AdManagerAdRequest.Builder(),
         callback: (AdManagerAdRequest, AudienzzResultCode?) -> Unit,
     ) {
-        val ppid = AudienzzPrebidMobile.ppidManager?.getPpid()
-        if (ppid != null) {
-            gamRequestBuilder.setPublisherProvidedId(ppid)
-        }
-
-        val request =
-            AudienzzTargetingParams.CUSTOM_TARGETING_MANAGER
-                .applyToGamRequestBuilder(gamRequestBuilder)
-                .build()
-
-        storedRequest = request
+        this.gamRequestBuilder = gamRequestBuilder
         storedCallback = callback
 
         if (withLazyLoading) {
@@ -92,19 +86,34 @@ class AudienzzAdViewHandler(
                 Log.d(TAG, "load() adUnitId=${adView.adUnitId} — lazy ON, prefetchMargin=${prefetchMarginDp}dp, waiting for view to enter range")
                 adView.addPrefetchMarginListener(marginDp = prefetchMarginDp) {
                     Log.d(TAG, "load() adUnitId=${adView.adUnitId} — prefetch margin reached (${prefetchMarginDp}dp), starting fetchDemand")
-                    fetchDemand(request, callback)
+                    fetchDemand()
                 }
             } else {
                 Log.d(TAG, "load() adUnitId=${adView.adUnitId} — lazy ON, prefetchMargin=0 (exact visibility), waiting for view to appear")
                 adView.addOnBecameVisibleOnScreenListener {
                     Log.d(TAG, "load() adUnitId=${adView.adUnitId} — view became visible, starting fetchDemand")
-                    fetchDemand(request, callback)
+                    fetchDemand()
                 }
             }
         } else {
             Log.d(TAG, "load() adUnitId=${adView.adUnitId} — lazy OFF, starting fetchDemand immediately")
-            fetchDemand(request, callback)
+            fetchDemand()
         }
+    }
+
+    /**
+     * M1: builds a fresh [AdManagerAdRequest] from the retained builder, re-reading the PPID and
+     * re-applying current global targeting so every auction (including refreshes) reflects the
+     * latest PPID/consent/targeting instead of a snapshot frozen at first load. GAM's
+     * addCustomTargeting/setPublisherProvidedId overwrite per key, so reusing the builder does not
+     * duplicate values.
+     */
+    private fun buildRequest(): AdManagerAdRequest {
+        val builder = gamRequestBuilder ?: AdManagerAdRequest.Builder()
+        AudienzzPrebidMobile.ppidManager?.getPpid()?.let { builder.setPublisherProvidedId(it) }
+        return AudienzzTargetingParams.CUSTOM_TARGETING_MANAGER
+            .applyToGamRequestBuilder(builder)
+            .build()
     }
 
     /**
@@ -122,12 +131,8 @@ class AudienzzAdViewHandler(
         Log.d(TAG, "enableSmartRefresh() adUnitId=${adView.adUnitId} — smart refresh enabled, refreshInterval=${adUnit.autoRefreshTime}ms")
         smartRefreshListener = adView.addContinuousVisibilityListener(
             onBecameVisible = {
-                val request = storedRequest ?: run {
-                    Log.w(TAG, "smartRefresh adUnitId=${adView.adUnitId} — became visible but storedRequest is null, skipping")
-                    return@addContinuousVisibilityListener
-                }
-                val callback = storedCallback ?: run {
-                    Log.w(TAG, "smartRefresh adUnitId=${adView.adUnitId} — became visible but storedCallback is null, skipping")
+                if (storedCallback == null) {
+                    Log.w(TAG, "smartRefresh adUnitId=${adView.adUnitId} — became visible but not loaded yet (no callback), skipping")
                     return@addContinuousVisibilityListener
                 }
                 if (lastRefreshTime == 0L) {
@@ -149,13 +154,13 @@ class AudienzzAdViewHandler(
 
                 if (remaining == 0L) {
                     Log.d(TAG, "smartRefresh adUnitId=${adView.adUnitId} — became visible, ad is STALE (elapsed=${elapsed}ms >= interval=${refreshIntervalMs}ms), force-refreshing now")
-                    fetchDemand(request, callback)
+                    fetchDemand()
                     adUnit.resumeAutoRefresh()
                 } else {
                     Log.d(TAG, "smartRefresh adUnitId=${adView.adUnitId} — became visible, ad is fresh (elapsed=${elapsed}ms, remaining=${remaining}ms), scheduling refresh in ${remaining}ms")
                     val runnable = Runnable {
                         Log.d(TAG, "smartRefresh adUnitId=${adView.adUnitId} — scheduled refresh fired after ${remaining}ms delay")
-                        fetchDemand(request, callback)
+                        fetchDemand()
                         adUnit.resumeAutoRefresh()
                     }
                     pendingRefreshRunnable = runnable
@@ -169,6 +174,16 @@ class AudienzzAdViewHandler(
                 adUnit.stopAutoRefresh()
             },
         )
+
+        // C3: onBecameHidden above is edge-triggered (visible -> hidden). A view that was
+        // prefetched while off-screen and is still not on screen never produced that edge, so its
+        // auto-refresh — armed by the prefetch fetchDemand — would loop forever at 0% viewability.
+        // Do an initial *level* check here: if the view isn't visible yet, stop refresh now; the
+        // onBecameVisible edge will resume/refresh it (stale-aware) once it enters the viewport.
+        if (!adView.isVisibleForSmartRefresh()) {
+            Log.d(TAG, "enableSmartRefresh() adUnitId=${adView.adUnitId} — view not visible at enable time (likely prefetched off-screen), stopping auto-refresh until it enters the viewport")
+            adUnit.stopAutoRefresh()
+        }
     }
 
     /**
@@ -196,12 +211,8 @@ class AudienzzAdViewHandler(
      * resets Prebid's timer to 0, ignoring however long the ad has already been displayed.
      */
     fun resumeSmartRefresh() {
-        val request = storedRequest ?: run {
-            Log.w(TAG, "resumeSmartRefresh() adUnitId=${adView.adUnitId} — storedRequest is null, skipping")
-            return
-        }
-        val callback = storedCallback ?: run {
-            Log.w(TAG, "resumeSmartRefresh() adUnitId=${adView.adUnitId} — storedCallback is null, skipping")
+        if (storedCallback == null) {
+            Log.w(TAG, "resumeSmartRefresh() adUnitId=${adView.adUnitId} — not loaded yet (no callback), skipping")
             return
         }
 
@@ -227,13 +238,13 @@ class AudienzzAdViewHandler(
 
         if (remaining == 0L) {
             Log.d(TAG, "resumeSmartRefresh() adUnitId=${adView.adUnitId} — ad is STALE (elapsed=${elapsed}ms >= interval=${refreshIntervalMs}ms), force-refreshing now")
-            fetchDemand(request, callback)
+            fetchDemand()
             adUnit.resumeAutoRefresh()
         } else {
             Log.d(TAG, "resumeSmartRefresh() adUnitId=${adView.adUnitId} — ad is fresh (elapsed=${elapsed}ms, remaining=${remaining}ms), scheduling refresh in ${remaining}ms")
             val runnable = Runnable {
                 Log.d(TAG, "resumeSmartRefresh() adUnitId=${adView.adUnitId} — scheduled refresh fired after ${remaining}ms delay")
-                fetchDemand(request, callback)
+                fetchDemand()
                 adUnit.resumeAutoRefresh()
             }
             pendingRefreshRunnable = runnable
@@ -254,10 +265,32 @@ class AudienzzAdViewHandler(
         pendingRefreshRunnable = null
     }
 
-    private fun fetchDemand(
-        request: AdManagerAdRequest,
-        callback: (AdManagerAdRequest, AudienzzResultCode?) -> Unit,
-    ) {
+    /**
+     * Releases all refresh and lifecycle resources held by this handler: stops smart refresh,
+     * cancels any pending scheduled refresh, stops Prebid's auto-refresh and destroys the
+     * underlying Prebid ad unit (tearing down its [org.prebid.mobile.BidLoader] so no further
+     * auctions fire), and drops the retained request/callback.
+     *
+     * H1: without this there was no way to stop the refresh loop or release the
+     * `BidLoader -> listener -> adView -> Activity` chain on view detach / Activity destroy when
+     * smart refresh is off (the default). Call from the host's lifecycle teardown (e.g. Activity
+     * `onDestroy` or a RecyclerView `onViewRecycled`). The handler must not be reused afterwards.
+     */
+    fun destroy() {
+        Log.d(TAG, "destroy() adUnitId=${adView.adUnitId}")
+        disableSmartRefresh()
+        adUnit.stopAutoRefresh()
+        adUnit.destroy()
+        gamRequestBuilder = null
+        storedCallback = null
+    }
+
+    private fun fetchDemand() {
+        val callback = storedCallback ?: run {
+            Log.w(TAG, "fetchDemand() adUnitId=${adView.adUnitId} — no stored callback, skipping")
+            return
+        }
+        val request = buildRequest()
         val isAutorefresh = adUnit.autoRefreshTime > 0
         val autorefreshTime = adUnit.autoRefreshTime.toLong()
         val isRefresh = !isFirstDemandFetch
@@ -275,6 +308,12 @@ class AudienzzAdViewHandler(
             isAutorefresh = isAutorefresh,
             isRefresh = isRefresh,
         )
+        // C1: Prebid's fetchDemand spawns a NEW self-re-arming BidLoader on every call without
+        // destroying the previous one. Stopping auto-refresh before each manual fetch guarantees
+        // the prior loader is cancelled first, so at most one refresh loop is ever live — otherwise
+        // each prefetch/scroll/resume fetch stacks another 30s auction loop that keeps auctioning
+        // (and GAM-loading) the view until process death.
+        adUnit.stopAutoRefresh()
         adUnit.fetchDemand(request) { resultCode ->
             lastRefreshTime = System.currentTimeMillis()
             setEventsListenerToAdView()
@@ -296,6 +335,13 @@ class AudienzzAdViewHandler(
     }
 
     private fun setEventsListenerToAdView() {
+        // H2: install the analytics wrapper exactly once. This method runs in every auction's
+        // completion (initial + each Prebid auto-refresh); re-wrapping each time nested the prior
+        // wrapper, so after N refreshes a single real click fired adClick N+1 times (and re-invoked
+        // the publisher's callbacks N+1 times). GAM reuses the same adView listener across
+        // refreshes, so wrapping the publisher's listener once is sufficient.
+        if (eventListenerInstalled) return
+        eventListenerInstalled = true
         val actualListener: AdListener? = adView.adListener
         adView.adListener = object : AdListener() {
 

--- a/Audienzz/src/main/java/org/audienzz/mobile/original/AudienzzInterstitialAdHandler.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/original/AudienzzInterstitialAdHandler.kt
@@ -99,35 +99,60 @@ class AudienzzInterstitialAdHandler(
     ): AudienzzInterstitialAdLoadCallback {
         return object : AudienzzInterstitialAdLoadCallback() {
             override fun onAdLoaded(adManagerInterstitialAd: AdManagerInterstitialAd) {
-                adLoadCallback?.onAdLoaded(adManagerInterstitialAd)
                 super.onAdLoaded(adManagerInterstitialAd)
+                adLoadCallback?.onAdLoaded(adManagerInterstitialAd)
+                // H5: the publisher may set their own FullScreenContentCallback on the ad inside
+                // their onAdLoaded (the GAM-documented pattern). Capture whatever they set and
+                // delegate to it so our analytics wrapper does not clobber their dismiss/fail/etc.
+                // callbacks; fall back to the callback passed to load() when they didn't set one.
+                val publisherDirectCallback = adManagerInterstitialAd.fullScreenContentCallback
                 adManagerInterstitialAd.fullScreenContentCallback =
                     object : FullScreenContentCallback() {
                         override fun onAdClicked() {
                             super.onAdClicked()
-                            fullScreenContentCallback?.onAdClicked()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdClicked()
+                            } else {
+                                fullScreenContentCallback?.onAdClicked()
+                            }
                             eventLogger?.adClick(adUnitId)
                         }
 
                         override fun onAdDismissedFullScreenContent() {
                             super.onAdDismissedFullScreenContent()
-                            fullScreenContentCallback?.onAdDismissedFullScreenContent()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdDismissedFullScreenContent()
+                            } else {
+                                fullScreenContentCallback?.onAdDismissedFullScreenContent()
+                            }
                             eventLogger?.closeAd(adUnitId)
                         }
 
                         override fun onAdFailedToShowFullScreenContent(error: AdError) {
                             super.onAdFailedToShowFullScreenContent(error)
-                            fullScreenContentCallback?.onAdFailedToShowFullScreenContent(error)
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdFailedToShowFullScreenContent(error)
+                            } else {
+                                fullScreenContentCallback?.onAdFailedToShowFullScreenContent(error)
+                            }
                         }
 
                         override fun onAdImpression() {
                             super.onAdImpression()
-                            fullScreenContentCallback?.onAdImpression()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdImpression()
+                            } else {
+                                fullScreenContentCallback?.onAdImpression()
+                            }
                         }
 
                         override fun onAdShowedFullScreenContent() {
                             super.onAdShowedFullScreenContent()
-                            fullScreenContentCallback?.onAdShowedFullScreenContent()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdShowedFullScreenContent()
+                            } else {
+                                fullScreenContentCallback?.onAdShowedFullScreenContent()
+                            }
                         }
                     }
             }

--- a/Audienzz/src/main/java/org/audienzz/mobile/original/AudienzzRewardedVideoAdHandler.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/original/AudienzzRewardedVideoAdHandler.kt
@@ -100,33 +100,57 @@ class AudienzzRewardedVideoAdHandler(
         return object : AudienzzRewardedAdLoadCallback() {
             override fun onAdLoaded(rewardedAd: RewardedAd) {
                 adLoadCallback?.onAdLoaded(rewardedAd)
+                // H5: delegate to the publisher's own FullScreenContentCallback if they set one on
+                // the ad inside their onAdLoaded (GAM-documented pattern) instead of clobbering it;
+                // fall back to the callback passed to load().
+                val publisherDirectCallback = rewardedAd.fullScreenContentCallback
                 rewardedAd.fullScreenContentCallback =
                     object : FullScreenContentCallback() {
                         override fun onAdClicked() {
                             super.onAdClicked()
                             eventLogger?.adClick(adUnitId)
-                            fullScreenContentCallback?.onAdClicked()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdClicked()
+                            } else {
+                                fullScreenContentCallback?.onAdClicked()
+                            }
                         }
 
                         override fun onAdDismissedFullScreenContent() {
                             super.onAdDismissedFullScreenContent()
                             eventLogger?.closeAd(adUnitId)
-                            fullScreenContentCallback?.onAdDismissedFullScreenContent()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdDismissedFullScreenContent()
+                            } else {
+                                fullScreenContentCallback?.onAdDismissedFullScreenContent()
+                            }
                         }
 
                         override fun onAdFailedToShowFullScreenContent(error: AdError) {
                             super.onAdFailedToShowFullScreenContent(error)
-                            fullScreenContentCallback?.onAdFailedToShowFullScreenContent(error)
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdFailedToShowFullScreenContent(error)
+                            } else {
+                                fullScreenContentCallback?.onAdFailedToShowFullScreenContent(error)
+                            }
                         }
 
                         override fun onAdImpression() {
                             super.onAdImpression()
-                            fullScreenContentCallback?.onAdImpression()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdImpression()
+                            } else {
+                                fullScreenContentCallback?.onAdImpression()
+                            }
                         }
 
                         override fun onAdShowedFullScreenContent() {
                             super.onAdShowedFullScreenContent()
-                            fullScreenContentCallback?.onAdShowedFullScreenContent()
+                            if (publisherDirectCallback != null) {
+                                publisherDirectCallback.onAdShowedFullScreenContent()
+                            } else {
+                                fullScreenContentCallback?.onAdShowedFullScreenContent()
+                            }
                         }
                     }
             }

--- a/Audienzz/src/main/java/org/audienzz/mobile/repository/RemoteConfigRepositoryImpl.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/repository/RemoteConfigRepositoryImpl.kt
@@ -3,6 +3,7 @@ package org.audienzz.mobile.repository
 import android.util.Log
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
 import org.audienzz.mobile.api.config.PublisherConfig
 import org.audienzz.mobile.api.config.RemoteAdUnitConfig
 import org.audienzz.mobile.api.config.RemoteConfigApi
@@ -36,23 +37,28 @@ internal class RemoteConfigRepositoryImpl @Inject constructor(
 
             // Fetch Ad Unit Configs
             Log.d(TAG, "Fetching ad unit configs...")
-            val adUnitConfigs = api.getAdUnitConfigs(publisherId)
-            Log.d(TAG, "Fetched ${adUnitConfigs.size} ad unit configs")
-            val entities = adUnitConfigs.map { config ->
-                Log.d(
-                    TAG,
-                    "Config: $config",
-                )
-                RemoteConfigEntity(
-                    configId = config.id.toString(),
-                    adUnitId = config.gamConfig.adUnitPath,
-                    adType = config.config.adType,
-                    data = json.encodeToString(config),
-                    timestamp = System.currentTimeMillis(),
-                )
+            val adUnitConfigsJson = api.getAdUnitConfigs(publisherId)
+            Log.d(TAG, "Fetched ${adUnitConfigsJson.size} ad unit config elements")
+            // H9: decode each element independently so a single malformed entry is skipped rather
+            // than throwing and discarding the whole config set (which recreated the cold-start
+            // "no config" state for every ad unit).
+            val entities = adUnitConfigsJson.mapNotNull { element ->
+                try {
+                    val config = json.decodeFromJsonElement<RemoteAdUnitConfig>(element)
+                    RemoteConfigEntity(
+                        configId = config.id.toString(),
+                        adUnitId = config.gamConfig.adUnitPath,
+                        adType = config.config.adType,
+                        data = json.encodeToString(config),
+                        timestamp = System.currentTimeMillis(),
+                    )
+                } catch (e: Exception) {
+                    Log.e(TAG, "Skipping malformed ad unit config element: $element", e)
+                    null
+                }
             }
             dao.insertAdConfigs(entities)
-            Log.d(TAG, "Config refreshed successfully for publisher: $publisherId")
+            Log.d(TAG, "Config refreshed: stored ${entities.size}/${adUnitConfigsJson.size} ad unit configs for publisher: $publisherId")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to refresh config for publisher: $publisherId", e)
         }

--- a/Audienzz/src/main/java/org/audienzz/mobile/util/ViewUtil.kt
+++ b/Audienzz/src/main/java/org/audienzz/mobile/util/ViewUtil.kt
@@ -25,7 +25,9 @@ fun View.isVisibleOnScreen() =
 private fun View.getGlobalVisibleRectIgnoringSize(outRect: Rect): Boolean {
     val extraPadding = 1
     outRect.set(-extraPadding, -extraPadding, width + extraPadding, height + extraPadding)
-    return parent == null || parent.getChildVisibleRect(this, outRect, null)
+    // H3: a detached view (parent == null) is NOT on screen. Treating it as visible made a
+    // recycled/detached slot report "visible" and trigger fetchDemand storms.
+    return parent != null && parent.getChildVisibleRect(this, outRect, null)
 }
 
 /**
@@ -46,6 +48,21 @@ private fun View.visibleHeightFraction(): Float {
 }
 
 /**
+ * Smart refresh fires only when at least this fraction of the ad height is visible, avoiding
+ * triggering on a pixel-sliver as the ad enters or leaves the viewport.
+ */
+private const val SMART_REFRESH_VISIBILITY_THRESHOLD = 0.2f
+
+/**
+ * True when at least [SMART_REFRESH_VISIBILITY_THRESHOLD] of the view's height is on screen — the
+ * same threshold [addContinuousVisibilityListener] uses to decide visible vs hidden. Exposed so
+ * callers can do a one-off *level* check (e.g. stop refresh for a prefetched-but-not-yet-visible
+ * view) rather than waiting for an edge transition that may never come.
+ */
+fun View.isVisibleForSmartRefresh(): Boolean =
+    visibleHeightFraction() >= SMART_REFRESH_VISIBILITY_THRESHOLD
+
+/**
  * Triggers [listener] if view is already visible on screen or subscribes to
  * [ViewTreeObserver.OnPreDrawListener]
  *
@@ -62,13 +79,10 @@ fun View.addContinuousVisibilityListener(
     onBecameVisible: () -> Unit,
     onBecameHidden: () -> Unit,
 ): ViewTreeObserver.OnPreDrawListener {
-    // Smart refresh fires only when at least 20% of the ad height is visible.
-    // This avoids triggering on a pixel-sliver when the ad is just entering or
-    // leaving the viewport.
-    var wasVisible = visibleHeightFraction() >= 0.2f
+    var wasVisible = isVisibleForSmartRefresh()
     val listener = object : ViewTreeObserver.OnPreDrawListener {
         override fun onPreDraw(): Boolean {
-            val isVisible = visibleHeightFraction() >= 0.2f
+            val isVisible = isVisibleForSmartRefresh()
             if (isVisible && !wasVisible) {
                 wasVisible = true
                 onBecameVisible()
@@ -87,10 +101,15 @@ fun View.addOnBecameVisibleOnScreenListener(listener: () -> Unit) {
     if (isVisibleOnScreen()) {
         listener()
     } else {
-        viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
+        // H3: capture the observer we register on. After an attach/detach the view's current
+        // viewTreeObserver can be a different instance, so removing via the property would be a
+        // silent no-op and the listener would leak and fire every frame.
+        val registrationObserver = viewTreeObserver
+        registrationObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
             override fun onPreDraw(): Boolean {
                 if (isVisibleOnScreen()) {
-                    viewTreeObserver.removeOnPreDrawListener(this)
+                    val observer = if (registrationObserver.isAlive) registrationObserver else viewTreeObserver
+                    observer.removeOnPreDrawListener(this)
                     listener()
                 }
                 return true
@@ -113,7 +132,8 @@ fun View.addOnBecameVisibleOnScreenListener(listener: () -> Unit) {
 fun View.isWithinPrefetchMargin(@Px marginPx: Int): Boolean {
     if (visibility != View.VISIBLE) return false
     val expandedRect = Rect(-marginPx, -marginPx, width + marginPx, height + marginPx)
-    return parent == null || parent.getChildVisibleRect(this, expandedRect, null)
+    // H3: a detached view (parent == null) is not within any viewport — do not treat it as in range.
+    return parent != null && parent.getChildVisibleRect(this, expandedRect, null)
 }
 
 /**
@@ -166,11 +186,14 @@ fun View.addPrefetchMarginListener(
         return
     }
     logPosition("registered, waiting")
-    viewTreeObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
+    // H3: remove from the observer we registered on (see addOnBecameVisibleOnScreenListener).
+    val registrationObserver = viewTreeObserver
+    registrationObserver.addOnPreDrawListener(object : ViewTreeObserver.OnPreDrawListener {
         override fun onPreDraw(): Boolean {
             if (isWithinPrefetchMargin(marginPx)) {
                 logPosition("entered prefetch zone → triggering load")
-                viewTreeObserver.removeOnPreDrawListener(this)
+                val observer = if (registrationObserver.isAlive) registrationObserver else viewTreeObserver
+                observer.removeOnPreDrawListener(this)
                 onReady()
             }
             return true


### PR DESCRIPTION
Remediates the 2026-07-06 Android SDK audit findings on main (all Critical, High except H7/PPID, and non-analytics Medium).

Critical
- C1: stop auto-refresh before every manual fetchDemand so orphaned Prebid BidLoaders can't stack into parallel refresh loops.
- C2: hand the publisher back the existing AudienzzInterstitialAdUnit instead of a new wrapper whose init re-installed a no-op listener, which clobbered the publisher's listener after the first callback.
- C3: initial level-check in enableSmartRefresh stops refresh for a prefetched-but-off-screen view (the hidden edge never fired).

High
- H1: add AudienzzAdViewHandler.destroy() (+ Prebid adUnit.destroy()); RemoteBannerView.destroy() routes through it.
- H2: install the analytics adListener wrapper once, not per auction (was firing adClick N+1 times after N refreshes).
- H3: treat parent == null as NOT visible; remove one-shot VTO listeners from the registration-time observer.
- H4/M10: onPause/onResume route through pause/resumeSmartRefresh so the pending postDelayed refresh can't fire while backgrounded.
- H5: fullscreen handlers delegate to the publisher's own FullScreenContentCallback instead of clobbering it.
- H6: single canonical global ORTB merge model (publisher ORTB + schain
  + keywords + SDK identity) so no source wipes another.
- H8: RemoteConfigManager awaits the initial refresh on a cold-start cache miss instead of returning null with no retry.
- H9: decode the ad-config batch element-wise so one malformed entry no longer discards every config.

Medium (non-analytics)
- M1: rebuild a fresh request per auction (current PPID/consent/targeting) instead of replaying a frozen AdManagerAdRequest.
- M4: bind applicationContext in the DI graph (was pinning the Activity).
- M5: buffer consent/COPPA set before init and replay on init complete.
- M6: surface RemoteConfigInterstitial dead-ends via Events.onError; destroy() releases the loaded ad.
- M11: destroy the predecessor ad unit/view when createAdFromConfig rebuilds.
- M12: sticky wrapper uses an additive ViewTreeObserver scroll listener instead of the single-slot setter that clobbered the publisher's.

Skipped intentionally: H7 (PPID consent gate), M3/L7/L15 (analytics), M7 (MRAID), M8 (1x1 interstitial format), M9 (muted-by-default is intentional), M2 (deferred - shared analytics DB).